### PR TITLE
For some reason workers did not exit when cocaine closed them. It looks ...

### DIFF
--- a/cocaine/worker.go
+++ b/cocaine/worker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"time"
+	"os"
 
 	"github.com/satori/go.uuid"
 	"github.com/ugorji/go/codec"
@@ -229,7 +230,7 @@ func (worker *Worker) Loop(bind map[string]EventHandler) {
 
 				case *terminateStruct:
 					worker.logger.Info("Receive terminate")
-					return
+					os.Exit(0)
 
 				default:
 					worker.logger.Warn("Unknown message")
@@ -241,7 +242,7 @@ func (worker *Worker) Loop(bind map[string]EventHandler) {
 
 		case <-worker.disown_timer.C:
 			worker.logger.Info("Disowned")
-			return
+			os.Exit(0)
 
 		case outcoming := <-worker.from_handlers:
 			worker.Write() <- outcoming


### PR DESCRIPTION
...like there is some complicated problem that requires serious debugging. This commit is a quick fix that forcibly closes the application. Two day tests shown that it worked. There may be still a problem though with small probability.
