### PR TITLE
[Worker] blackhole all writes on socket error

### DIFF
--- a/cocaine/asocket.go
+++ b/cocaine/asocket.go
@@ -134,6 +134,13 @@ func (sock *asyncRWSocket) writeloop() {
 			_, err := sock.Conn.Write(incoming) //Add check for sending full
 			if err != nil {
 				sock.close()
+				// blackhole all writes
+				go func() {
+					ok := true
+					for ok {
+						_, ok = <-sock.clientToSock.out
+					}
+				}()
 				return
 			}
 		}


### PR DESCRIPTION
It will prevent event loop from getting stuck when runtime server dies.