### PR TITLE
[Response] Get rid of a dispatch loop in response.

### DIFF
--- a/cocaine12/workerv0_test.go
+++ b/cocaine12/workerv0_test.go
@@ -96,22 +96,6 @@ func TestWorkerV0(t *testing.T) {
 	sock2.Write() <- newChunkV0(testSession, []byte("Dummy"))
 	sock2.Write() <- newChokeV0(testSession)
 
-	sock2.Write() <- newInvokeV0(testSession+1, "http")
-	sock2.Write() <- newChunkV0(testSession+1, packTestReq(req))
-	sock2.Write() <- newChokeV0(testSession + 1)
-
-	sock2.Write() <- newInvokeV0(testSession+2, "error")
-	sock2.Write() <- newChunkV0(testSession+2, []byte("Dummy"))
-	sock2.Write() <- newChokeV0(testSession + 2)
-
-	sock2.Write() <- newInvokeV0(testSession+3, "BadEvent")
-	sock2.Write() <- newChunkV0(testSession+3, []byte("Dummy"))
-	sock2.Write() <- newChokeV0(testSession + 3)
-
-	sock2.Write() <- newInvokeV0(testSession+4, "panic")
-	sock2.Write() <- newChunkV0(testSession+4, []byte("Dummy"))
-	sock2.Write() <- newChokeV0(testSession + 4)
-
 	// handshake
 	eHandshake := <-sock2.Read()
 	checkTypeAndSession(t, eHandshake, 0, handshakeType)
@@ -140,6 +124,9 @@ func TestWorkerV0(t *testing.T) {
 	checkTypeAndSession(t, eChoke, testSession, chokeType)
 
 	// http event
+	sock2.Write() <- newInvokeV0(testSession+1, "http")
+	sock2.Write() <- newChunkV0(testSession+1, packTestReq(req))
+	sock2.Write() <- newChokeV0(testSession + 1)
 	// status code & headers
 	t.Log("HTTP test:")
 	eChunk = <-sock2.Read()
@@ -160,6 +147,10 @@ func TestWorkerV0(t *testing.T) {
 
 	// error event
 	t.Log("error event")
+	sock2.Write() <- newInvokeV0(testSession+2, "error")
+	sock2.Write() <- newChunkV0(testSession+2, []byte("Dummy"))
+	sock2.Write() <- newChokeV0(testSession + 2)
+
 	eError := <-sock2.Read()
 	checkTypeAndSession(t, eError, testSession+2, errorType)
 	eChoke = <-sock2.Read()
@@ -167,6 +158,10 @@ func TestWorkerV0(t *testing.T) {
 
 	// badevent
 	t.Log("badevent event")
+	sock2.Write() <- newInvokeV0(testSession+3, "BadEvent")
+	sock2.Write() <- newChunkV0(testSession+3, []byte("Dummy"))
+	sock2.Write() <- newChokeV0(testSession + 3)
+
 	eError = <-sock2.Read()
 	checkTypeAndSession(t, eError, testSession+3, errorType)
 	eChoke = <-sock2.Read()
@@ -174,6 +169,10 @@ func TestWorkerV0(t *testing.T) {
 
 	// panic
 	t.Log("panic event")
+	sock2.Write() <- newInvokeV0(testSession+4, "panic")
+	sock2.Write() <- newChunkV0(testSession+4, []byte("Dummy"))
+	sock2.Write() <- newChokeV0(testSession + 4)
+
 	eError = <-sock2.Read()
 	checkTypeAndSession(t, eError, testSession+4, errorType)
 	eChoke = <-sock2.Read()

--- a/cocaine12/workerv1_bench_test.go
+++ b/cocaine12/workerv1_bench_test.go
@@ -1,0 +1,73 @@
+package cocaine12
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+func genBullets(sock *asyncRWSocket, bullets uint64) {
+	for i := uint64(2); i < 2+bullets; i++ {
+		sock.Write() <- newInvokeV1(i, "echo")
+		sock.Write() <- newChunkV1(i, []byte("Dummy"))
+		sock.Write() <- newChokeV1(i)
+	}
+}
+
+func doBenchmarkWorkerEcho(b *testing.B, bullets uint64) {
+	const (
+		testID      = "uuid"
+		testSession = 10
+	)
+
+	in, out := testConn()
+	sock, _ := newAsyncRW(out)
+	sock2, _ := newAsyncRW(in)
+	w, err := newWorker(sock, testID, 1, true)
+	if err != nil {
+		panic(err)
+	}
+
+	w.disownTimer = time.NewTimer(1 * time.Hour)
+	w.heartbeatTimer = time.NewTimer(1 * time.Hour)
+
+	w.On("echo", func(ctx context.Context, req Request, resp Response) {
+		defer resp.Close()
+
+		data, err := req.Read()
+		if err != nil {
+			panic(err)
+		}
+		resp.Write(data)
+	})
+
+	go func() {
+		w.Run(nil)
+	}()
+	defer w.Stop()
+
+	genBullets(sock2, bullets)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := uint64(0); j < bullets; j++ {
+			// chunk
+			<-sock2.Read()
+			// choke
+			<-sock2.Read()
+		}
+	}
+}
+
+func BenchmarkWorkerEcho10(b *testing.B) {
+	doBenchmarkWorkerEcho(b, 10)
+}
+
+func BenchmarkWorkerEcho100(b *testing.B) {
+	doBenchmarkWorkerEcho(b, 100)
+}
+
+func BenchmarkWorkerEcho1000(b *testing.B) {
+	doBenchmarkWorkerEcho(b, 1000)
+}

--- a/cocaine12/workerv1_test.go
+++ b/cocaine12/workerv1_test.go
@@ -66,22 +66,6 @@ func TestWorkerV1(t *testing.T) {
 	sock2.Write() <- newChunkV1(testSession, []byte("Dummy"))
 	sock2.Write() <- newChokeV1(testSession)
 
-	sock2.Write() <- newInvokeV1(testSession+1, "http")
-	sock2.Write() <- newChunkV1(testSession+1, packTestReq(req))
-	sock2.Write() <- newChokeV1(testSession + 1)
-
-	sock2.Write() <- newInvokeV1(testSession+2, "error")
-	sock2.Write() <- newChunkV1(testSession+2, []byte("Dummy"))
-	sock2.Write() <- newChokeV1(testSession + 2)
-
-	sock2.Write() <- newInvokeV1(testSession+3, "BadEvent")
-	sock2.Write() <- newChunkV1(testSession+3, []byte("Dummy"))
-	sock2.Write() <- newChokeV1(testSession + 3)
-
-	sock2.Write() <- newInvokeV1(testSession+4, "panic")
-	sock2.Write() <- newChunkV1(testSession+4, []byte("Dummy"))
-	sock2.Write() <- newChokeV1(testSession + 4)
-
 	// handshake
 	eHandshake := <-sock2.Read()
 	checkTypeAndSession(t, eHandshake, v1UtilitySession, v1Handshake)
@@ -112,6 +96,10 @@ func TestWorkerV1(t *testing.T) {
 	// http event
 	// status code & headers
 	t.Log("HTTP test:")
+	sock2.Write() <- newInvokeV1(testSession+1, "http")
+	sock2.Write() <- newChunkV1(testSession+1, packTestReq(req))
+	sock2.Write() <- newChokeV1(testSession + 1)
+
 	eChunk = <-sock2.Read()
 	checkTypeAndSession(t, eChunk, testSession+1, v1Write)
 	var firstChunk struct {
@@ -130,6 +118,10 @@ func TestWorkerV1(t *testing.T) {
 
 	// error event
 	t.Log("error event")
+	sock2.Write() <- newInvokeV1(testSession+2, "error")
+	sock2.Write() <- newChunkV1(testSession+2, []byte("Dummy"))
+	sock2.Write() <- newChokeV1(testSession + 2)
+
 	eError := <-sock2.Read()
 	checkTypeAndSession(t, eError, testSession+2, v1Error)
 	eChoke = <-sock2.Read()
@@ -137,6 +129,10 @@ func TestWorkerV1(t *testing.T) {
 
 	// badevent
 	t.Log("badevent event")
+	sock2.Write() <- newInvokeV1(testSession+3, "BadEvent")
+	sock2.Write() <- newChunkV1(testSession+3, []byte("Dummy"))
+	sock2.Write() <- newChokeV1(testSession + 3)
+
 	eError = <-sock2.Read()
 	checkTypeAndSession(t, eError, testSession+3, v1Error)
 	eChoke = <-sock2.Read()
@@ -144,6 +140,10 @@ func TestWorkerV1(t *testing.T) {
 
 	// panic
 	t.Log("panic event")
+	sock2.Write() <- newInvokeV1(testSession+4, "panic")
+	sock2.Write() <- newChunkV1(testSession+4, []byte("Dummy"))
+	sock2.Write() <- newChokeV1(testSession + 4)
+
 	eError = <-sock2.Read()
 	checkTypeAndSession(t, eError, testSession+4, v1Error)
 	eChoke = <-sock2.Read()


### PR DESCRIPTION
Data is written directly to outcoming connection. It avoids spawning of a goroutine per session. Messages don't pass via Worker's dispatch loop, which is highly loaded even without them.

@lamerman @mechmind PTAL if you want

I also have an idea to remove a request loop.