### PR TITLE
fix cocaine11 response error code unpack

### DIFF
--- a/cocaine/message.go
+++ b/cocaine/message.go
@@ -173,8 +173,8 @@ func (msg *chunk) getPayload() []interface{} {
 func unpackErrorMsg(session int64, data []interface{}) (msg messageInterface, err error) {
 	var code int
 	var message string
-	if code_t, ok := data[0].(int); ok {
-		code = code_t
+	if code_t, ok := data[0].(int64); ok {
+		code = int(code_t)
 	}
 	if message_t, ok := data[1].([]byte); ok {
 		message = string(message_t)


### PR DESCRIPTION
```
var res []interface{}
err := dec.Decode(&res)
```
`codec` decodes integers in `int64` when used with `interface{}`. Because of this
```
if code_t, ok := data[0].(int); ok {
```
`ok` is always false and unable to unpack error code.

cocaine12 seems does not have this bug due to extracting to target types, not `interface{}`.