### PR TITLE
Worker handlers refactoring

### DIFF
--- a/cocaine12/httphandler.go
+++ b/cocaine12/httphandler.go
@@ -124,7 +124,7 @@ func HeadersCocaineToHTTP(hdr Headers) http.Header {
 //		}
 //	}
 func WrapHandler(handler http.Handler) EventHandler {
-	var wrapper = func(ctx context.Context, request Request, response Response) {
+	return func(ctx context.Context, request Request, response Response) {
 		defer response.Close()
 
 		w, httpRequest, err := convertToHTTPFunc(ctx, request, response)
@@ -135,8 +135,6 @@ func WrapHandler(handler http.Handler) EventHandler {
 		handler.ServeHTTP(w, httpRequest)
 		w.finishRequest()
 	}
-
-	return wrapper
 }
 
 func WrapHTTPFunc(handler func(ctx context.Context, w http.ResponseWriter, req *http.Request)) EventHandler {

--- a/cocaine12/worker_handlers.go
+++ b/cocaine12/worker_handlers.go
@@ -1,0 +1,54 @@
+package cocaine12
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+)
+
+// EventHandler represents a type of handler
+type EventHandler func(context.Context, Request, Response)
+
+// RequestHandler represents a type of handler
+type RequestHandler func(context.Context, string, Request, Response)
+
+// TerminationHandler invokes when termination message is received
+type TerminationHandler func(context.Context)
+
+type EventHandlers struct {
+	fallback RequestHandler
+	handlers map[string]EventHandler
+}
+
+func NewEventHandlersFromMap(handlers map[string]EventHandler) *EventHandlers {
+	return &EventHandlers{DefaultFallbackHandler, handlers}
+}
+
+func NewEventHandlers() *EventHandlers {
+	return NewEventHandlersFromMap(make(map[string]EventHandler))
+}
+
+func (e *EventHandlers) On(name string, handler EventHandler) {
+	e.handlers[name] = handler
+}
+
+// SetFallbackHandler sets the handler to be a fallback handler
+func (e *EventHandlers) SetFallbackHandler(handler RequestHandler) {
+	e.fallback = handler
+}
+
+// DefaultFallbackHandler sends an error message if a client requests
+// unhandled event
+func DefaultFallbackHandler(ctx context.Context, event string, request Request, response Response) {
+	errMsg := fmt.Sprintf("There is no handler for an event %s", event)
+	response.ErrorMsg(ErrorNoEventHandler, errMsg)
+}
+
+func (e *EventHandlers) Call(ctx context.Context, event string, request Request, response Response) {
+	handler := e.handlers[event]
+	if handler == nil {
+		e.fallback(ctx, event, request, response)
+		return
+	}
+	handler(ctx, request, response)
+}

--- a/cocaine12/workerv1_bench_test.go
+++ b/cocaine12/workerv1_bench_test.go
@@ -32,7 +32,8 @@ func doBenchmarkWorkerEcho(b *testing.B, bullets uint64) {
 	w.disownTimer = time.NewTimer(1 * time.Hour)
 	w.heartbeatTimer = time.NewTimer(1 * time.Hour)
 
-	w.On("echo", func(ctx context.Context, req Request, resp Response) {
+	handlers := NewEventHandlers()
+	handlers.On("echo", func(ctx context.Context, req Request, resp Response) {
 		defer resp.Close()
 
 		data, err := req.Read(ctx)
@@ -43,7 +44,7 @@ func doBenchmarkWorkerEcho(b *testing.B, bullets uint64) {
 	})
 
 	go func() {
-		w.Run(nil)
+		w.Run(handlers.Call, nil)
 	}()
 	defer w.Stop()
 

--- a/cocaine12/workerv1_test.go
+++ b/cocaine12/workerv1_test.go
@@ -61,7 +61,7 @@ func TestWorkerV1(t *testing.T) {
 		t.Fatal("unable to create worker", err)
 	}
 
-	handlers := map[string]EventHandler{
+	handlers := NewEventHandlersFromMap(map[string]EventHandler{
 		"test": func(ctx context.Context, req Request, res Response) {
 			data, _ := req.Read(ctx)
 			t.Logf("Request data: %s", data)
@@ -84,10 +84,10 @@ func TestWorkerV1(t *testing.T) {
 		"panic": func(ctx context.Context, req Request, res Response) {
 			panic("PANIC")
 		},
-	}
+	})
 
 	go func() {
-		w.Run(handlers)
+		w.Run(handlers.Call, nil)
 		close(onStop)
 	}()
 
@@ -199,7 +199,7 @@ func TestWorkerV1Termination(t *testing.T) {
 	}
 
 	go func() {
-		w.Run(map[string]EventHandler{})
+		w.Run(nil, nil)
 		close(onStop)
 	}()
 
@@ -269,7 +269,9 @@ func TestWorkerLoad(t *testing.T) {
 		t.Fatal("unable to create worker", err)
 	}
 
-	w.On("echo", func(ctx context.Context, req Request, res Response) {
+	handlers := NewEventHandlers()
+
+	handlers.On("echo", func(ctx context.Context, req Request, res Response) {
 		defer res.Close()
 		req.Read(ctx)
 		time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
@@ -277,7 +279,7 @@ func TestWorkerLoad(t *testing.T) {
 	})
 
 	go func() {
-		w.Run(map[string]EventHandler{})
+		w.Run(handlers.Call, nil)
 	}()
 
 	j := 0


### PR DESCRIPTION
The main idea is removing map of handlers from worker implementation and letting user to handle it with a single handler. That would make it easier to change behaviour onfly by the user.

NOTE that this request changes the interface of Run and removes the On method from Worker. Hope that this change is possible.

Also note, that the behaviour in Fallback changed a bit - it have Span now.