### PR TITLE
Add DC() stub method for DefaultValues

### DIFF
--- a/cocaine12/defaults.go
+++ b/cocaine12/defaults.go
@@ -50,6 +50,12 @@ func (d *defaultValues) UUID() string {
 	return d.uuid
 }
 
+func (d *defaultValues) DC() string {
+	// TODO(mechmind): return real DC when cocaine runtime will support this
+	// falling back to "global" if dc location is not available
+	return "global"
+}
+
 func (d *defaultValues) Token() Token {
 	return d.token
 }
@@ -63,6 +69,7 @@ type DefaultValues interface {
 	Locators() []string
 	Protocol() int
 	UUID() string
+	DC() string
 	Token() Token
 }
 


### PR DESCRIPTION
DC hint feature request was accepted, so I there is an interface update for that. We will use provided dc hint for proper metric names (along with instance UUID) for monitoring.